### PR TITLE
Fix promotions section placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
                         <textarea id="flight_notes" name="flight_notes" placeholder="Ajoutez ici des détails importants (ex: compagnie, escale, type de bagages inclus...)"></textarea>
                     </div>                 
                     </div>
+            </div>
             <div class="form-section">
                 <h2>Promotion</h2>
                 <label for="promotion_type">Type de promotion&nbsp;:</label>


### PR DESCRIPTION
## Summary
- close the flights section with a missing `</div>` so the promotions section stands on its own

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c33a17ba88326a40e88c47de73b35