### PR TITLE
Add logos to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,16 @@
         #emailOutputContainer { margin-top: 30px; }
         #emailOutput { padding: 20px; border: 1px solid #ccc; background-color: #f0f2f5; border-radius: 8px; min-height: 200px; overflow-x: auto;}
         .flight-inputs { border: 1px solid #ddd; border-radius: 8px; padding: 10px 15px 15px 15px; margin-top:10px; }
+        .header-logos { display: flex; justify-content: space-between; align-items: center; background-color: #eceff1; padding: 10px; border-radius: 8px; margin-bottom: 20px; }
+        .header-logos img { max-height: 80px; }
     </style>
 </head>
 <body>
     <div class="container">
+        <div class="header-logos">
+            <img src="https://www.voyagesenroute.com/wp-content/uploads/2024/12/logo-argent-300x151.webp" alt="Logo agence">
+            <img src="https://www.voyagesenroute.com/wp-content/uploads/2024/10/Logo_Fond_Blanc_2.svg" alt="Earmarked">
+        </div>
         <h1>Générateur d'e-mail Disney</h1>
         <form id="disneyForm">
             <div class="form-section">
@@ -223,6 +229,16 @@
             };
             
             let introSection = `<p style="${S.p}">${T.greeting}</p><p style="${S.p}">${T.intro1}</p><p style="${S.p}">${T.intro2}</p>`;
+            const logosEmail = `<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#eceff1;margin:20px 0;border-radius:8px;">
+                                    <tr>
+                                        <td style="width:50%;text-align:center;padding:10px;">
+                                            <img src="https://www.voyagesenroute.com/wp-content/uploads/2024/12/logo-argent-300x151.webp" alt="Logo agence" style="max-height:80px;">
+                                        </td>
+                                        <td style="width:50%;text-align:center;padding:10px;">
+                                            <img src="https://www.voyagesenroute.com/wp-content/uploads/2024/10/Logo_Fond_Blanc_2.svg" alt="Earmarked" style="max-height:80px;">
+                                        </td>
+                                    </tr>
+                                </table>`;
             let hotelSection = '';
             const selectedHotels = data.hotels || [];
 
@@ -252,9 +268,9 @@ if (selectedHotels.length === 1) {
                             </div>
                         </div>
                     `;
-                    hotelSection += `<p style="${S.p}">Pour votre séjour, voici l'option que j'ai sélectionnée pour vous :</p>${hotelCard}`;
+                    hotelSection += `<p style="${S.p}">Pour votre séjour, voici l'option que j'ai sélectionnée pour vous :</p>${logosEmail}${hotelCard}`;
                 } else {
-                    hotelSection += `<p style="${S.p}">Voici plusieurs options d’hébergement pour votre séjour. Chaque proposition ci-dessous correspond à un forfait détaillé dans un document PDF distinct.</p>`;
+                    hotelSection += `<p style="${S.p}">Voici plusieurs options d’hébergement pour votre séjour. Chaque proposition ci-dessous correspond à un forfait détaillé dans un document PDF distinct.</p>${logosEmail}`;
                     let hotelCards = '';
                     selectedHotels.forEach(hotel => {
                         const levelColor = C.level[hotel.level.toLowerCase().replace(/ /g, '_')] || C.textLight;


### PR DESCRIPTION
## Summary
- style agency and Earmarked logos inside email
- place logo block after the `votre séjour` paragraph so they appear near the hotel options

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c51e19778832696d1dbb6c225c82e