### PR TITLE
Fix ticket-only option

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,7 +549,18 @@ if (selectedHotels.length === 1) {
             // --- FIN DE LA FONCTION À AJOUTER ---
 
             function toggleHotelOptions() {
-                hotelOptionsContainer.classList.toggle('hidden', bookingTypeSelect.value !== 'hotel_tickets');
+                const isHotelBooking = bookingTypeSelect.value === 'hotel_tickets';
+                hotelOptionsContainer.classList.toggle('hidden', !isHotelBooking);
+
+                const hotelNameSelects = hotelOptionsContainer.querySelectorAll('select[name="hotel_name"]');
+                hotelNameSelects.forEach(select => {
+                    if (isHotelBooking) {
+                        select.setAttribute('required', '');
+                    } else {
+                        select.removeAttribute('required');
+                        select.value = '';
+                    }
+                });
             }
 
             function togglePromotionDetails() {


### PR DESCRIPTION
## Summary
- fix input validation when selecting Disney tickets without hotel options

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c56e219448326ade6201f5555d591