### PR TITLE
Add logos and tagline to email

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,12 @@
                 strong: `font-weight: bold;`,
                 italic: `font-style: italic;`,
             };
+
+            const LOGOS = {
+                agency: 'https://www.voyagesenroute.com/wp-content/uploads/2024/10/Logo_Fond_Blanc_2.svg',
+                earmarked: 'https://i.ibb.co/GQVYyJn2/Disney-Organisateur-de-vacances-autorise-Disney-Ear-Marked-argent-1-1-e1722367433886.png'
+            };
+            const TAGLINE = 'Le top votre aventure magique commence ici.';
             
             function createBanner(text, type = 'main') {
                 let style, titleStyle, wrapperStyle;
@@ -342,6 +348,8 @@ if (selectedHotels.length === 1) {
             const hotelBannerText = data.booking_type === 'tickets_only' ? "Billets de Parc Disney" : "Forfaits Hôtel & Billets Disney";
 
             return `<!DOCTYPE html><html lang="fr"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${T.banner1}</title></head><body style="margin:0; padding:0; background-color:${C.background};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:${C.background};"><tr><td align="center"><table width="680" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 680px; max-width: 100%; margin: 20px auto; background-color: ${C.white};">
+                <tr><td style="padding:20px 30px 10px 30px; background-color:${C.white};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td align="center" style="width:50%;"><img src="${LOGOS.earmarked}" alt="Logo Earmarked" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td><td align="center" style="width:50%;"><img src="${LOGOS.agency}" alt="Logo agence" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td></tr></table></td></tr>
+                <tr><td style="padding:0 30px 20px 30px; text-align:center; font-family:${S.fontStack}; font-size:16px; font-weight:bold; color:${C.textDark}; background-color:${C.white};">${TAGLINE}</td></tr>
                 ${createBanner(T.banner1, 'main')}
                 <tr><td style="padding: 20px 30px 30px 30px;">${introSection}</td></tr>
                 ${createBanner(hotelBannerText, 'sub')}


### PR DESCRIPTION
## Summary
- show agency and Earmarked logos in generated email
- add tagline after the logos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c742995d883268c22ad3c47b0a26e