### PR TITLE
Remove tagline row and add header background

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
                 white: '#FFFFFF',
                 blueLight: '#e6f2fa',
                 orangeLight: '#fff4e6',
+                headerBg: '#FDEBD0',
                 level: { value: '#28a745', moderate: '#2196F3', deluxe: '#6f42c1', deluxe_villa: '#9C27B0' },
                 tags: ['#0078C1', '#5A67D8', '#d9480f', '#0ca678']
             };
@@ -346,8 +347,7 @@ if (selectedHotels.length === 1) {
             const hotelBannerText = data.booking_type === 'tickets_only' ? "Billets de Parc Disney" : "Forfaits Hôtel & Billets Disney";
 
             return `<!DOCTYPE html><html lang="fr"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${T.banner1}</title></head><body style="margin:0; padding:0; background-color:${C.background};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:${C.background};"><tr><td align="center"><table width="680" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 680px; max-width: 100%; margin: 20px auto; background-color: ${C.white};">
-                <tr><td style="padding:20px 30px 10px 30px; background-color:${C.blueLight};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td align="center" style="width:50%;"><img src="${LOGOS.earmarked}" alt="Logo Earmarked" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td><td align="center" style="width:50%;"><img src="${LOGOS.agency}" alt="Logo agence" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td></tr></table></td></tr>
-                <tr><td style="padding:0 30px 20px 30px; text-align:center; font-family: Georgia, serif; font-size:20px; font-weight:bold; color:${C.textDark}; background-color:${C.blueLight};">${TAGLINE}</td></tr>
+                <tr><td style="padding:20px 30px 10px 30px; background-color:${C.headerBg};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td align="center" style="width:50%;"><img src="${LOGOS.earmarked}" alt="Logo Earmarked" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td><td align="center" style="width:50%;"><img src="${LOGOS.agency}" alt="Logo agence" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td></tr></table></td></tr>
                 ${createBanner(T.banner1, 'main')}
                 <tr><td style="padding: 20px 30px 30px 30px;">${introSection}</td></tr>
                 ${createBanner(hotelBannerText, 'sub')}


### PR DESCRIPTION
## Summary
- eliminate the unused tagline row from the email template
- add a custom `headerBg` color and apply it to the logo header

## Testing
- `grep -n TAGLINE -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_684c7bde46c8832696c316edef4977c7