### PR TITLE
Update logo header background

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,15 +360,13 @@ if (selectedHotels.length === 1) {
       color-scheme: light dark;
       supported-color-schemes: light dark;
     }
-    @media (prefers-color-scheme: dark) {
-      .logo-background {
-        background-color: #FFFFFF !important;
-      }
+    .logo-background {
+      background-color: #e9f2f9 !important;
     }
   </style>
 </head>
 <body style="margin:0; padding:0; background-color:${C.background};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:${C.background};"><tr><td align="center"><table width="680" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 680px; max-width: 100%; margin: 20px auto; background-color: ${C.white};"
-<tr><td class="logo-background" style="padding:20px 30px 10px 30px; background-color:${C.blueLight};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td align="center" style="width:50%;"><img src="${LOGOS.earmarked}" alt="Logo Earmarked" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td><td align="center" style="width:50%;"><img src="${LOGOS.agency}" alt="Logo agence" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td></tr></table></td></tr>                ${createBanner(T.banner1, 'main')}
+<tr><td class="logo-background" style="padding:20px 30px 10px 30px; background-color:#e9f2f9;"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td align="center" style="width:50%;"><img src="${LOGOS.earmarked}" alt="Logo Earmarked" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td><td align="center" style="width:50%;"><img src="${LOGOS.agency}" alt="Logo agence" style="max-width:150px; height:auto; display:block; margin:0 auto;"></td></tr></table></td></tr>                ${createBanner(T.banner1, 'main')}
                 <tr><td style="padding: 20px 30px 30px 30px;">${introSection}</td></tr>
                 ${createBanner(hotelBannerText, 'sub')}
                 <tr><td style="padding: 20px 30px 10px 30px;">${hotelSection}</td></tr>


### PR DESCRIPTION
## Summary
- set a fixed background color for the email header logos
- ensure header color is always `rgb(233, 242, 249)`

## Testing
- `html5validator --help` *(fails: command not found)*
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684c97e4f36c8326beb53e79ac7aa00a