### PR TITLE
Fix Gmail header darkening

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,13 +352,13 @@ if (selectedHotels.length === 1) {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="x-apple-disable-message-reformatting">
-  <meta name="color-scheme" content="light dark">
-  <meta name="supported-color-schemes" content="light dark">
+  <meta name="color-scheme" content="light">
+  <meta name="supported-color-schemes" content="light">
   <title>${T.banner1}</title>
   <style>
     :root {
-      color-scheme: light dark;
-      supported-color-schemes: light dark;
+      color-scheme: light;
+      supported-color-schemes: light;
     }
     .logo-background {
       background-color: #e9f2f9 !important;


### PR DESCRIPTION
## Summary
- disable dark-mode transformation by declaring light-only color scheme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ca0d366788326a5edb3b40f7c8e1b