### PR TITLE
Adjust logo banner with new dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                 textDark: '#222222',
                 textLight: '#555555',
                 border: '#EAEAEA',
-                background: '#f0f2f5',
+                background: '#001f3f',
                 white: '#FFFFFF',
                 blueLight: '#e6f2fa',
                 orangeLight: '#fff4e6',
@@ -361,37 +361,35 @@ if (selectedHotels.length === 1) {
       supported-color-schemes: light dark;
     }
     .logo-background {
-      background-color: #e9f2f9 !important;
+      background-color: #001f3f !important;
+    }
+    .logo-container {
+      background-color: #e9f2f9;
+      padding: 20px 30px;
+      border-radius: 8px;
+      max-width: 420px;
+      margin: auto;
     }
     @media (prefers-color-scheme: dark) {
       .logo-background {
-        background-color: #e9f2f9 !important;
-        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGN4+eknAAWcAtWhsYB8AAAAAElFTkSuQmCC') !important;
+        background-color: #001f3f !important;
       }
     }
   </style>
 </head>
 <body style="margin:0; padding:0; background-color:${C.background};"><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:${C.background};"><tr><td align="center"><table width="680" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 680px; max-width: 100%; margin: 20px auto; background-color: ${C.white};"
-<tr><td class="logo-background" style="padding:20px 30px 10px 30px; background-color:#e9f2f9;">
-
 <tr>
-  <td
-    class="logo-background"
-    align="center"
-    bgcolor="#e9f2f9"
-    background="https://boisterous-rabanadas-5fcb72.netlify.app/blue.png"
-    style="padding:20px 30px 10px 30px; background-color:#e9f2f9; background-image:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGN4+eknAAWcAtWhsYB8AAAAAElFTkSuQmCC'); background-repeat: repeat; background-size: auto;">
-    
-    <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
-           <tr>
-       <td align="center" style="width:50%;">
-         <img src="${LOGOS.earmarked}" alt="Logo Earmarked" style="max-width:150px; height:auto; display:block; margin:0 auto;">
-       </td>
-       <td align="center" style="width:50%;">
-         <img src="${LOGOS.agency}" alt="Logo agence" style="max-width:150px; height:auto; display:block; margin:0 auto;">
-       </td>
-     </tr>
-      </table>
+  <td class="logo-background" align="center" style="padding:20px 0;">
+    <table class="logo-container" border="0" cellpadding="0" cellspacing="0" role="presentation">
+      <tr>
+        <td align="center" style="width:50%;">
+          <img src="${LOGOS.earmarked}" alt="Logo Earmarked" style="max-width:150px; height:auto; display:block; margin:0 auto;">
+        </td>
+        <td align="center" style="width:50%;">
+          <img src="${LOGOS.agency}" alt="Logo agence" style="max-width:150px; height:auto; display:block; margin:0 auto;">
+        </td>
+      </tr>
+    </table>
   </td>
 </tr>
 


### PR DESCRIPTION
## Summary
- add dark background to generated email
- center logos in a smaller light-blue box

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ca26c85388326b27ea0da1e502ee3