### PR TITLE
Fix email styling for Outlook light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,18 +383,10 @@ if (selectedHotels.length === 1) {
       }
     }
   </style>
-  <!--[if mso]>
-  <style type="text/css">
-    body, table, td, p, span, a, h1, h2, h3, h4 {
-      background-color: #001f3f !important;
-      color: #ffffff !important;
-    }
-  </style>
-  <![endif]-->
 </head>
 <body style="margin:0; padding:0; background-color:${C.background};" bgcolor="${C.background}" data-ogsb data-ogsc><table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:${C.background};"><tr><td align="center"><table width="680" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 680px; max-width: 100%; margin: 20px auto; background-color: ${C.white};"
 <tr>
-  <td class="logo-background" align="center" style="padding:20px 0;">
+  <td class="logo-background" align="center" style="padding:20px 0; background-color:#001f3f;">
     <table class="logo-container" border="0" cellpadding="0" cellspacing="0" role="presentation">
       <tr>
         <td align="center" style="width:50%;">


### PR DESCRIPTION
## Summary
- remove Outlook-specific dark style override
- add explicit background color on logo row for better Gmail display

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cc0aea3c48326a416021061d60ef1